### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,10 @@ concurrency:
   group: "publish-${{ github.ref }}"
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/devops-actions/github-copilot-premium-reqs-usage/security/code-scanning/1](https://github.com/devops-actions/github-copilot-premium-reqs-usage/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, the following permissions are likely needed:
- `contents: read` for accessing repository contents.
- `packages: write` for uploading assets.
- `pull-requests: write` if interacting with pull requests is required.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`build-and-publish`) to limit its scope.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
